### PR TITLE
fix(ci): remove redundant environment variable setting in workflow

### DIFF
--- a/.github/workflows/test-agent-scenarios.yml
+++ b/.github/workflows/test-agent-scenarios.yml
@@ -35,7 +35,6 @@ jobs:
         run: |
           curl -fsSL https://claude.ai/install.sh | bash
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "$HOME/.local/bin" >> $GITHUB_ENV
 
       - name: Verify Claude CLI
         run: claude --version


### PR DESCRIPTION
- Removed duplicate line that adds Claude CLI path to $GITHUB_ENV