### PR TITLE
Fix Cursor submission blockers: skill router naming, changelog date, version links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ ALWAYS use these exact terms. Inconsistency confuses agents and users.
 ```
 hookdeck/agent-skills/
   skills/
-    hookdeck/                          # Master router -- dispatches to product skills
+    hookdeck/                          # Skill router -- dispatches to product skills
       SKILL.md
     event-gateway/                     # ONE comprehensive skill
       SKILL.md                         # ~90 lines: use cases, staged workflow, reference tables
@@ -208,7 +208,7 @@ Before merging a new or updated skill, verify:
 - [ ] No general webhook/API education that agents already know
 - [ ] No time-sensitive information (dates, version predictions)
 - [ ] Consistent terminology throughout all files in the skill
-- [ ] Skill name has product prefix (`event-gateway` or `outpost`, or `hookdeck` for the master router)
+- [ ] Skill name has product prefix (`event-gateway` or `outpost`, or `hookdeck` for the skill router)
 
 ### Quality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - Unreleased
+## [0.2.0] - 2025-02-21
 
 ### Added
 
@@ -23,3 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skills: `hookdeck` (router), `event-gateway`, `outpost`
 - Staged integration workflow (setup, scaffold, listen, iterate)
 - Reference documentation and working examples (Express, Next.js, FastAPI)
+
+[0.2.0]: https://github.com/hookdeck/agent-skills/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/hookdeck/agent-skills/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npx skills add hookdeck/agent-skills --skill outpost
 
 | Skill | Purpose | Use when... |
 |---|---|---|
-| `hookdeck` | Master router | You need help with any Hookdeck product and aren't sure which skill to use |
+| `hookdeck` | Skill router | You need help with any Hookdeck product and aren't sure which skill to use |
 | `event-gateway` | Receive, route, and deliver webhooks | Getting started with Hookdeck, receiving webhooks, configuring connections, local development, monitoring, or API automation |
 | `outpost` | Send webhooks to customers | Sending events to customer endpoints via HTTP, SQS, RabbitMQ, Pub/Sub, or other destinations |
 

--- a/skills/outpost/SKILL.md
+++ b/skills/outpost/SKILL.md
@@ -134,5 +134,5 @@ Destination-specific skills (`outpost-webhooks`, `outpost-sqs`, `outpost-rabbitm
 
 ## Related Skills
 
-- [hookdeck](https://github.com/hookdeck/agent-skills/blob/main/skills/hookdeck/SKILL.md) -- master router for all Hookdeck skills
+- [hookdeck](https://github.com/hookdeck/agent-skills/blob/main/skills/hookdeck/SKILL.md) -- skill router for all Hookdeck skills
 - [event-gateway](https://github.com/hookdeck/agent-skills/blob/main/skills/event-gateway/SKILL.md) -- Hookdeck Event Gateway (inbound webhooks)


### PR DESCRIPTION
## Summary
Applies reviewer feedback for Cursor Marketplace submission:

**Must Fix:**
- Change "master router" to "skill router" everywhere (skills/outpost, AGENTS.md, README.md)
- Update CHANGELOG [0.2.0] from Unreleased to 2025-02-21
- Add Keep a Changelog version links at bottom of CHANGELOG

**Should Fix:**
- All "Master router" references updated in AGENTS.md
- Version link references added for [0.2.0] and [0.1.0]

Made with [Cursor](https://cursor.com)