### PR TITLE
Add plugin marketplace structure

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "description": "Hookdeck plugin marketplace: skills for Hookdeck Event Gateway and Hookdeck Outpost.",
   "plugins": [
     {
-      "name": "hookdeck-skills",
+      "name": "hookdeck",
       "source": "./",
       "description": "Skills for working with Hookdeck Event Gateway (receive, queue, route, and deliver webhooks) and Hookdeck Outpost (send webhooks and events to user-preferred destinations). Includes a router skill that delegates to event-gateway or outpost based on the task."
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "hookdeck-agent-skills",
+  "owner": {
+    "name": "Hookdeck",
+    "email": "phil@hookdeck.com"
+  },
+  "description": "Hookdeck plugin marketplace: skills for Hookdeck Event Gateway and Hookdeck Outpost.",
+  "plugins": [
+    {
+      "name": "hookdeck-skills",
+      "source": "./",
+      "description": "Skills for working with Hookdeck Event Gateway (receive, queue, route, and deliver webhooks) and Hookdeck Outpost (send webhooks and events to user-preferred destinations). Includes a router skill that delegates to event-gateway or outpost based on the task."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "hookdeck-skills",
+  "name": "hookdeck",
   "version": "0.1.0",
   "description": "Skills for working with Hookdeck Event Gateway (receive, queue, route, and deliver webhooks) and Hookdeck Outpost (send webhooks and events to user-preferred destinations). Includes a router skill that delegates to event-gateway or outpost based on the task.",
   "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "hookdeck-skills",
+  "version": "0.1.0",
+  "description": "Skills for working with Hookdeck Event Gateway (receive, queue, route, and deliver webhooks) and Hookdeck Outpost (send webhooks and events to user-preferred destinations). Includes a router skill that delegates to event-gateway or outpost based on the task.",
+  "author": {
+    "name": "Hookdeck",
+    "email": "phil@hookdeck.com"
+  },
+  "homepage": "https://github.com/hookdeck/agent-skills"
+}


### PR DESCRIPTION
## Summary

Adds `.claude-plugin/` metadata so this repo is a valid Claude Code plugin marketplace and can be submitted to the community marketplace ([Claude.ai submission form](https://claude.ai/settings/plugins/submit)). The three existing skills are bundled as a single plugin. No SKILL.md content, scripts, or tooling are modified, this is purely additive metadata.

## What was added

- `.claude-plugin/marketplace.json` — marketplace catalog with one plugin entry, `source: "./"` (the marketplace root itself).
- `.claude-plugin/plugin.json` — plugin manifest, version `0.1.0`.

Existing skill layout (`skills/<name>/SKILL.md` at the repo root) already matches the plugin spec, so nothing had to move.

## Why

Adding the marketplace manifest lets users discover and install these skills through Claude Code's `/plugin marketplace add` flow and the various community plugin indexers. It's also the prerequisite for submitting to the official Anthropic marketplace.

## Naming

Per Anthropic's [marketplace docs](https://code.claude.com/docs/en/plugin-marketplaces), the bare name `agent-skills` is reserved and rejected by the Claude.ai marketplace sync, alongside `claude-code-marketplace`, `claude-code-plugins`, `claude-plugins-official`, `anthropic-marketplace`, `anthropic-plugins`, `knowledge-work-plugins`, and `life-sciences`. The GitHub repo name (`hookdeck/agent-skills`) is unaffected, only the values inside the JSON manifests had to be changed.

Chosen names:

- **Marketplace `name`**: `hookdeck-agent-skills`
- **Plugin `name`**: `hookdeck`

Inside Claude Code the skills are namespaced as:

- `hookdeck:hookdeck` (the router skill)
- `hookdeck:event-gateway`
- `hookdeck:outpost`

### Plugin name convention

The plugin name follows the convention used by other single-plugin vendors in the official Anthropic marketplace: plain brand name, no `-skills` or `-plugin` suffix. Examples from the [official marketplace catalog](https://github.com/anthropics/claude-plugins-official/blob/main/.claude-plugin/marketplace.json):

| Vendor | Plugin `name` | Source repo |
|---|---|---|
| Vercel | `vercel` | [vercel/vercel-plugin](https://github.com/vercel/vercel-plugin) |
| Supabase | `supabase` | [supabase-community/supabase-plugin](https://github.com/supabase-community/supabase-plugin) |
| Cloudflare | `cloudflare` | [cloudflare/skills](https://github.com/cloudflare/skills) |
| Sentry | `sentry` | [getsentry/sentry-for-claude](https://github.com/getsentry/sentry-for-claude) |
| Stripe, Firebase, Linear, Prisma, MongoDB, PlanetScale, Railway | plain brand | various |

The slightly tautological `hookdeck:hookdeck` namespace for the router skill mirrors the established `supabase:supabase` pattern in [supabase/agent-skills](https://github.com/supabase/agent-skills), so this is a recognised shape in the ecosystem.

If we ever ship a second plugin from this repo we can switch to prefixed names (the AWS pattern: `aws-amplify`, `aws-core`, `aws-data-analytics`).

## Validation

Validated locally with the bundled CLI:

```
$ claude plugin validate .
Validating marketplace manifest: .../.claude-plugin/marketplace.json
✔ Validation passed
```

Also smoke-tested loading the plugin with `claude --plugin-dir .` and confirmed all three skills resolve as `hookdeck:hookdeck`, `hookdeck:event-gateway`, and `hookdeck:outpost`.

## Test plan

- [x] `claude plugin validate .` passes
- [x] `claude --plugin-dir .` loads the plugin and lists all three skills with the `hookdeck:` prefix
- [ ] After merge, add the marketplace from the GitHub source and install: `/plugin marketplace add hookdeck/agent-skills` then `/plugin install hookdeck@hookdeck-agent-skills`
- [ ] Submit to the official marketplace via https://claude.ai/settings/plugins/submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)