### PR TITLE
docs: update Homebrew CLI install to brew install hookdeck

### DIFF
--- a/skills/event-gateway/examples/express/README.md
+++ b/skills/event-gateway/examples/express/README.md
@@ -18,7 +18,7 @@ npm start
 Install the Hookdeck CLI on your machine before the steps below. Official guide (all platforms): **[Install the Hookdeck CLI](https://hookdeck.com/docs/cli#installation)** · [Hookdeck CLI overview](https://hookdeck.com/docs/cli).
 
 ```bash
-brew install hookdeck/hookdeck/hookdeck
+brew install hookdeck
 # or
 npm install -g hookdeck-cli
 ```

--- a/skills/event-gateway/examples/fastapi/README.md
+++ b/skills/event-gateway/examples/fastapi/README.md
@@ -18,7 +18,7 @@ python main.py
 Install the Hookdeck CLI on your machine before the steps below. Official guide (all platforms): **[Install the Hookdeck CLI](https://hookdeck.com/docs/cli#installation)** · [Hookdeck CLI overview](https://hookdeck.com/docs/cli).
 
 ```bash
-brew install hookdeck/hookdeck/hookdeck
+brew install hookdeck
 # or
 npm install -g hookdeck-cli
 ```

--- a/skills/event-gateway/examples/nextjs/README.md
+++ b/skills/event-gateway/examples/nextjs/README.md
@@ -18,7 +18,7 @@ npm run dev
 Install the Hookdeck CLI on your machine before the steps below. Official guide (all platforms): **[Install the Hookdeck CLI](https://hookdeck.com/docs/cli#installation)** · [Hookdeck CLI overview](https://hookdeck.com/docs/cli).
 
 ```bash
-brew install hookdeck/hookdeck/hookdeck
+brew install hookdeck
 # or
 npm install -g hookdeck-cli
 ```

--- a/skills/event-gateway/references/01-setup.md
+++ b/skills/event-gateway/references/01-setup.md
@@ -18,7 +18,7 @@ Get from zero to a working Hookdeck connection. Default path: **receive webhooks
 ## Install the CLI
 
 ```sh
-brew install hookdeck/hookdeck/hookdeck
+brew install hookdeck
 ```
 
 Or via npm:

--- a/skills/event-gateway/references/cli-workflows.md
+++ b/skills/event-gateway/references/cli-workflows.md
@@ -20,7 +20,7 @@ Prefer **`hookdeck gateway … upsert`** over `create` when both exist so workfl
 
 **Canonical rule for agents:** Before you **run** or **document** any `hookdeck …` command for the user (`listen`, `login`, `gateway …`, etc.), **ensure the Hookdeck CLI is installed** and **say so in user-facing text** (README, runbook, chat) the first time such a command appears—do not assume `hookdeck` is on PATH.
 
-**Copy-paste install examples:** `brew install hookdeck/hookdeck/hookdeck` or `npm i -g hookdeck-cli`. More options (devDependency, `npx hookdeck`, verify with `hookdeck version`) are in [Installation](#installation) below.
+**Copy-paste install examples:** `brew install hookdeck` or `npm i -g hookdeck-cli`. More options (devDependency, `npx hookdeck`, verify with `hookdeck version`) are in [Installation](#installation) below.
 
 **Official install (all platforms):** [hookdeck.com/docs/cli.md#installation](https://hookdeck.com/docs/cli.md#installation) — same content as the [CLI overview](https://hookdeck.com/docs/cli); the full CLI reference lives on that page / in [cli.md](https://hookdeck.com/docs/cli.md).
 
@@ -29,7 +29,7 @@ Prefer **`hookdeck gateway … upsert`** over `create` when both exist so workfl
 ## Installation
 
 ```sh
-brew install hookdeck/hookdeck/hookdeck
+brew install hookdeck
 ```
 
 Or via npm:


### PR DESCRIPTION
## Summary
- Replace `brew install hookdeck/hookdeck/hookdeck` with `brew install hookdeck` in event-gateway skill references and example READMEs.

## Test plan
- [ ] Spot-check setup and CLI workflow docs for updated install command

Made with [Cursor](https://cursor.com)