### PR TITLE
Say how many source types there are, and how to find them

### DIFF
--- a/skills/event-gateway/references/authentication.md
+++ b/skills/event-gateway/references/authentication.md
@@ -19,13 +19,25 @@ How the Hookdeck Event Gateway authenticates requests -- both inbound (from webh
 
 | Method | Use case |
 |--------|----------|
-| **[Source Types](https://hookdeck.com/docs/sources#source-types)** | Provider presets (Stripe, Shopify, GitHub, etc.) that auto-configure verification. **Default choice.** |
+| **[Source Types](https://hookdeck.com/docs/sources#source-types)** | Provider presets that auto-configure verification. **Default choice.** Over 150 providers have one, far beyond the well-known names -- check before assuming a provider is unsupported. |
 | **API Key** | Provider sends a static key in a header or query parameter |
 | **Basic Auth** | Provider sends Basic HTTP credentials |
 
 ### Source Types (Recommended)
 
-Source Types are platform presets that auto-configure signature verification for a provider:
+Source Types are platform presets that auto-configure signature verification for a provider. There are over 150, covering far more than the handful of names that appear in examples: AI platforms, payment processors, e-commerce, CRM, infrastructure and more.
+
+**Check whether your provider has one before falling back to a generic source.** A generic `WEBHOOK` source with hand-rolled verification is the wrong answer when a preset exists, because the preset already knows the provider's algorithm, header and encoding:
+
+```sh
+# List every available source type
+curl -s https://api.hookdeck.com/2025-07-01/openapi \
+  | jq -r '.components.schemas | keys[] | select(startswith("SourceTypeConfig")) | ltrimstr("SourceTypeConfig")'
+```
+
+The [Sources documentation](https://hookdeck.com/docs/sources#source-types) lists them with the configuration each one takes.
+
+Using a preset:
 
 Production-style (**HTTPS** destination):
 


### PR DESCRIPTION
`authentication.md` described source types as "Provider presets (Stripe, Shopify, GitHub, etc.)". There are 151.

## What this was doing

Measured in [hookdeck/evals](https://github.com/hookdeck/evals), on a scenario that asks an agent to receive ElevenLabs transcription callbacks and verify them.

| Configuration | Result |
|---|---|
| No skills | Created an `ELEVENLABS` source. 4/5 |
| **With this skill, before** | Created a generic `WEBHOOK` source, hand-rolled verification. **0/5** |
| With this skill, after | Created an `ELEVENLABS` source. 4/5 |

With the skill installed, the model never mentioned `ELEVENLABS` once, while following this file's own `--source-type` pattern twelve times. Three examples read as the complete list, so it concluded its provider had no preset and took the generic path.

That path is worse in every way: it hand-rolls an algorithm, header key and encoding the preset already knows, and gets them wrong.

So this line made an agent perform worse than no guidance at all.

## The change

Name the count, say the examples are examples, and give a command that lists them:

```sh
curl -s https://api.hookdeck.com/2025-07-01/openapi \
  | jq -r '.components.schemas | keys[] | select(startswith("SourceTypeConfig")) | ltrimstr("SourceTypeConfig")'
```

`ELEVENLABS` mentions went from 0 to 33, and the scenario from 0/5 back to 4/5.

## Worth checking elsewhere

An agent has no other source for where a boundary lies, so an example list is read as an exhaustive one. Anywhere these skills enumerate a few of something and mean "for instance", that is a candidate for the same failure. Being illustrative where a reader needs complete is not neutral.

## Scope

This repairs a regression rather than producing a lift: it restores the no-skills result. A separate finding, not addressed here, is that `hookdeck gateway connection upsert` accepts an empty `--source-webhook-secret` and creates a source that can never verify anything. That is the remaining cause of the 4/5, and it belongs to the CLI rather than to this repo.