### PR TITLE
event-gateway: document hookdeck ci for non-interactive environments

### DIFF
--- a/skills/event-gateway/SKILL.md
+++ b/skills/event-gateway/SKILL.md
@@ -13,6 +13,21 @@ The Event Gateway receives, routes, processes, and delivers webhooks and events.
 Always reference Hookdeck docs as the source of truth.
 See [references/referencing-docs.md](references/referencing-docs.md) for how to fetch docs as markdown.
 
+## Authenticating without a browser (agents, CI, sandboxes)
+
+`hookdeck login` needs a browser and `hookdeck login -i` needs a TTY. Use
+**`hookdeck ci`**, which reads `HOOKDECK_API_KEY` from the environment, before any
+other CLI command:
+
+```sh
+hookdeck ci        # exchanges the Project API key for CLI credentials
+hookdeck whoami    # confirm the expected organization and project
+```
+
+Without this the CLI creates a temporary guest account and keeps going, so commands
+appear to succeed against a project the user cannot see. See
+[references/cli-workflows.md#non-interactive-environments](references/cli-workflows.md#non-interactive-environments).
+
 ## CLI command model
 
 - Prefer `hookdeck gateway ...` for Event Gateway resource management, querying, and analysis.

--- a/skills/event-gateway/references/01-setup.md
+++ b/skills/event-gateway/references/01-setup.md
@@ -141,7 +141,7 @@ The `--source-type` flag uses a [Source Type](https://hookdeck.com/docs/sources#
 | `HOOKDECK_API_KEY` | API key for programmatic access. Found in [Dashboard > Settings > Secrets](https://dashboard.hookdeck.com/settings/project/secrets). |
 | `HOOKDECK_WEBHOOK_SECRET` | Signing secret for verifying the [Hookdeck Signature](https://hookdeck.com/docs/authentication#hookdeck-webhook-signature-verification) on forwarded events. Found in the same settings page. |
 
-Set these in your environment or `.env` file. The CLI uses browser-based auth via `hookdeck login` and does not require `HOOKDECK_API_KEY` for interactive CLI use.
+Set these in your environment or `.env` file. Interactive CLI use authenticates via `hookdeck login` and does not need `HOOKDECK_API_KEY`. Without a browser or a TTY, run [`hookdeck ci`](cli-workflows.md#non-interactive-environments) instead, which reads `HOOKDECK_API_KEY` and exchanges it for CLI credentials.
 
 ## Next Step
 

--- a/skills/event-gateway/references/cli-workflows.md
+++ b/skills/event-gateway/references/cli-workflows.md
@@ -55,9 +55,46 @@ hookdeck version
 
 ```sh
 hookdeck login     # Browser-based login
+hookdeck login -i  # Interactive, for when a browser cannot be opened (needs a TTY)
 hookdeck logout    # Clear credentials
 hookdeck whoami    # Show current user and project
 ```
+
+### Agents, CI and other non-interactive environments {#non-interactive-environments}
+
+`hookdeck login` needs a browser and `hookdeck login -i` needs a TTY, so neither works
+unattended. **`hookdeck ci` is the supported path**, and it reads `HOOKDECK_API_KEY`
+from the environment when the flag is omitted:
+
+```sh
+hookdeck ci                              # uses $HOOKDECK_API_KEY
+hookdeck ci --api-key <project-api-key>  # or pass it explicitly
+hookdeck listen 3000 <source_name> --path /webhooks
+```
+
+It exchanges the Project API key for CLI credentials and saves them, so subsequent
+commands are authenticated. `--name` labels the run in the dashboard, and `--local`
+writes credentials to `.hookdeck/config.toml` in the working directory rather than the
+user's home.
+
+Recent CLI versions also accept `hookdeck login --cli-key <cli-key>`, and `listen`
+itself falls back to `HOOKDECK_API_KEY`. **Do not rely on either when the CLI version
+is unknown**: `hookdeck ci` has been the non-interactive route for longer and works
+either way.
+
+**Authenticate first, then check it worked.** With no credentials the CLI creates a
+temporary guest account and carries on, so `hookdeck listen` appears to work while
+operating on a project the user cannot see, with no delivery history, retries or issue
+triggers:
+
+```sh
+hookdeck ci
+hookdeck whoami   # confirm the expected organization and project
+```
+
+If `whoami` shows a guest account, authentication did not happen. Do not present
+CLI-created resources as being in the user's project, and say what went wrong rather
+than falling back to a local-only setup and reporting the task as done.
 
 ## Project Management {#project-management}
 


### PR DESCRIPTION
The skill never mentioned `hookdeck ci`, `--api-key` or `--cli-key`. It documented
`hookdeck login` alone, which needs a browser, so an agent in a sandbox had no route
to authentication and no reason to think one existed.

This comes from a measurement in [hookdeck/evals](https://github.com/hookdeck/evals),
and is the first change made through that benchmark's improvement loop.

## What was measured

A deliberately weaker model (`gpt-5.4-mini`) scores **worse with this skill than
without it**: 10/15 against 13/15. Frontier models are +1 and 0, so the effect sits at
the weak end of the ladder.

Documentation lookups across the four scenarios it loses:

| | docs lookups |
|---|---|
| without this skill | **44** |
| with this skill | **2** |

The control makes it causal rather than coincidental: the one scenario the skill
**wins** is the one where the agent kept researching, 21 lookups against 24.

The clearest single case, setting up a Stripe source:

> "I also tried Hookdeck CLI account access, but the provided API key failed
> authentication in this sandbox, so I left the local `hookdeck listen` setup
> documented rather than creating cloud resources here."

It stopped there, having created nothing in the user's project. The same model without
this skill read the documentation and completed the task.

## The cause is this skill, not the CLI

`hookdeck ci` is the supported non-interactive path and predates the CLI version the
benchmark pins (2.3.1). At that version its flag is already declared as:

```go
lc.cmd.Flags().StringVar(&lc.apiKey, "api-key", os.Getenv("HOOKDECK_API_KEY"), ...)
```

So `hookdeck ci` with `HOOKDECK_API_KEY` set is enough. It exchanges the Project API
key for CLI credentials that later commands use, and its own example is exactly
`hookdeck ci` followed by `hookdeck listen`.

The skill documented none of it, and `01-setup.md` said the CLI "does not require
`HOOKDECK_API_KEY` for interactive CLI use" — true, but the qualifier is doing work an
agent will miss.

## The change

- **`cli-workflows.md`** gains a non-interactive section under Authentication:
  `hookdeck ci` with and without the flag, what it does with the key, `--name` and
  `--local`, and a caution against relying on newer paths (`login --cli-key`, `listen`
  reading the environment) when the CLI version is unknown.
- **`SKILL.md`** gains the two-command form up front. An agent that gets this wrong
  produces work in a project the user cannot see, so it is worth the front-loaded
  tokens.
- **`01-setup.md`** points to it when there is no browser or TTY.

All three also cover what happens when authentication is skipped: the CLI creates a
temporary guest account and carries on, so commands appear to succeed against a
project with no delivery history, retries or issue triggers. `hookdeck whoami` is the
check.

## Correction

An earlier revision of this PR claimed there was no unattended CLI login and told
agents to use the REST API instead. That was wrong on the facts, and would have
steered agents away from the CLI for a problem the CLI solves. It was caught in review
and the change was rewritten against the CLI source rather than against its `--help`
output, which hides the root `--api-key` flag.

## Verification

`npm run validate:plugin` and `npm run skill:lint` pass.

The benchmark re-run is the real test, and needs at least three attempts per scenario
to separate a fix from variance. Tracked in hookdeck/evals#9 and hookdeck/evals#10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nt2Zgjw7STjrnFXYKRRVAA
